### PR TITLE
Restart mongo after mongodb.conf change

### DIFF
--- a/installers/mongodb
+++ b/installers/mongodb
@@ -64,7 +64,7 @@ end
 
 
 # ## Restart mongo
-sudo service mongodb start
+sudo service mongodb restart
 or begin
   set -l err $status
   echo "Error: Failure restarting $PROG_NAME"


### PR DESCRIPTION
The mongodb restart was executing "sudo service mongodb start" which only works if the mongodb service is not already running. As the final bit of the mongodb install actually starts the service, this part fails, stops the script, and prints errors. I modified "start" to "restart" which alleviates the issue.
