### PR TITLE
adding mean.io stack, including grunt, mean and bundled stack

### DIFF
--- a/installers/grunt
+++ b/installers/grunt
@@ -1,0 +1,82 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Grunt"
+set -l REQ_STORAGE  2212
+set -l USERNAME     $USER
+
+
+# ## Check Requirements
+# ### Storage
+set -l available_storage (df / | awk 'NR>1{print $4}')
+if test (math $available_storage - $REQ_STORAGE) -lt 0
+  echo "
+$PROG_NAME requires at least "(math $REQ_STORAGE / 1024)"MB storage, \
+and you have "(math $available_storage / 1024)"MB free.
+
+Please free up some space, and try again. You can start by deleting any
+large files or directories in your home directory or delete software that
+you do not need.
+
+You can also upgrade your account to get more space, at the following url
+
+    https://koding.com/Pricing
+"
+  echo "Req Error: Not enough storage" >&2
+  exit 1
+end
+
+# ### Check if already installed
+if which grunt > /dev/null
+  echo "
+$PROG_NAME is already installed. It can be started with the following \
+command:
+
+    \$ grunt
+"
+  echo "Req Error: Already installed" >&2
+  exit 1
+end
+
+# ## Check if NodeJS installed
+if not which node > /dev/null
+  echo "
+$PROG_NAME requires that NodeJS is already installed. Please install
+NodeJS first.
+"
+  echo "Req Error: Missing node" >&2
+  exit 1
+end
+
+# ## Check if npm installed
+if not which npm > /dev/null
+  echo "
+$PROG_NAME requires that npm is already installed. Please install
+npm first.
+"
+  echo "Req Error: Missing npm" >&2
+  exit 1
+end
+
+# ## Install
+sudo npm install -g grunt-cli
+or begin
+  set -l err $status
+  echo "Error: Failure installing $PROG_NAME"
+  echo "Error: apt-get failed to install $PROG_NAME" >&2
+  exit $err
+end
+
+# ## Complete
+echo "
+Installation complete, and $PROG_NAME is now available.
+To use:
+\$ grunt
+In a directory containing a properly formatted Gruntfile and package.json.
+See http://gruntjs.com/getting-started for more information.
+"
+
+end
+main
+# vim: set filetype=fish:

--- a/installers/index.json
+++ b/installers/index.json
@@ -4,11 +4,15 @@
     "django",
     "dropbox",
     "ftp",
+	"grunt",
+	"mean",
+	"mean-io-stack",
     "meteor",
     "mysql",
     "mongodb",
     "phpmyadmin",
     "pip",
+    "rails",
     "ungit",
     "wordpress"
   ]

--- a/installers/mean
+++ b/installers/mean
@@ -1,0 +1,110 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Mean"
+set -l REQ_STORAGE  120508
+set -l USERNAME     $USER
+
+# ## Check Requirements
+# ### Storage
+set -l available_storage (df / | awk 'NR>1{print $4}')
+if test (math $available_storage - $REQ_STORAGE) -lt 0
+  echo "
+$PROG_NAME requires at least "(math $REQ_STORAGE / 1024)"MB storage, \
+and you have "(math $available_storage / 1024)"MB free.
+
+Please free up some space, and try again. You can start by deleting any
+large files or directories in your home directory or delete software that
+you do not need.
+
+You can also upgrade your account to get more space, at the following url
+
+    https://koding.com/Pricing
+"
+  echo "Req Error: Not enough storage" >&2
+  exit 1
+end
+
+# ### Check if already installed
+if which mean > /dev/null
+  echo "
+$PROG_NAME is already installed. It can be started with the following \
+command:
+
+    \$ mean myApp
+"
+  echo "Req Error: Already installed" >&2
+  exit 1
+end
+
+# ### Check if node is installed
+if not which node > /dev/null
+  echo "
+$PROG_NAME requires that NodeJS is already installed. Please
+install it first.
+"
+  echo "Req Error: Missing npm" >&2
+  exit 1
+end
+
+# ## Check if npm installed
+if not which npm > /dev/null
+  echo "
+$PROG_NAME requires that npm is already installed. Please install
+npm first.
+"
+  echo "Req Error: Missing npm" >&2
+  exit 1
+end
+
+# ## Check if mongodb installed
+if not which mongo > /dev/null
+  echo "
+$PROG_NAME requires that mongodb is already installed. Please install
+mongo first.
+"
+  echo "Req Error: Missing mongodb" >&2
+  exit 1
+end
+
+
+# ## Check if Grunt installed
+if not which grunt > /dev/null
+  echo "
+$PROG_NAME requires that grunt is already installed. Please install
+grunt first.
+"
+  echo "Req Error: Missing grunt" >&2
+  exit 1
+end
+
+
+
+# ## Install
+# ### build-essential - These will be needed for the user to npm install a mean project without getting bson errors
+sudo apt-get install gcc make build-essential
+
+# ### mean
+sudo npm install -g mean-cli
+or begin
+  set -l err $status
+  echo "Error: Failure installing $PROG_NAME"
+  echo "Error: npm failed to install $PROG_NAME" >&2
+  exit $err
+end
+
+
+
+# ## Complete
+echo "
+Installation complete, and $PROG_NAME is now available.
+To create a project:
+\$ mean init <myApp>
+\$ cd <myApp> && npm install
+"
+
+
+end
+main
+# vim: set filetype=fish:

--- a/installers/mean-io-stack
+++ b/installers/mean-io-stack
@@ -1,0 +1,71 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Mean.io Stack"
+set -l REQ_STORAGE  765628
+set -l USERNAME     $USER
+
+# ## Set installs in this bundle
+set -l bundled mongodb grunt mean
+set -l mongodb "mongod" 
+set -l grunt "grunt"
+set -l mean "mean"
+set -l installed 
+
+# ## Check Requirements
+# ### Storage
+set -l available_storage (df / | awk 'NR>1{print $4}')
+if test (math $available_storage - $REQ_STORAGE) -lt 0
+  echo "
+$PROG_NAME requires at least "(math $REQ_STORAGE / 1024)"MB storage, \
+and you have "(math $available_storage / 1024)"MB free.
+
+Please free up some space, and try again. You can start by deleting any
+large files or directories in your home directory or delete software that
+you do not need.
+
+You can also upgrade your account to get more space, at the following url
+
+    https://koding.com/Pricing
+"
+  echo "Req Error: Not enough storage" >&2
+  exit 1
+end
+
+# ## Install everything in the bundle
+for bundle in $bundled
+	if not set -q failed
+		if not which $$bundle > /dev/null
+   		 	echo "Installing $bundle"
+			kpm install $bundle
+   		 	#fish ./$bundle
+			if not which $$bundle > /dev/null
+				set -l failed
+			else
+				set installed  $installed  $bundle
+			end
+		else
+   			echo "$bundle already installed, skipping."
+		end
+	end
+end
+
+# ## Revert if any part failed
+if set -q failed
+	echo "One of the bundled installs failed."
+	echo "Reverting all installs performed in this package to return system to original state"
+	for install in $installed
+		echo "reverting $install"
+		kpm uninstall $install
+	end
+end
+
+# ## Complete
+echo "---------------------------------------------------------------------------------"
+echo "Installation complete, all installs in the $PROG_NAME completed successfully.  "
+echo "---------------------------------------------------------------------------------"
+
+end
+main
+# vim: set filetype=fish:

--- a/uninstallers/grunt
+++ b/uninstallers/grunt
@@ -1,0 +1,43 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Grunt"
+set -l USERNAME     $USER
+
+# ## Check Requirements
+# ### Check if installed
+if not which grunt > /dev/null
+  echo "
+A $PROG_NAME installation cannot be found.
+"
+  echo "Req Error: Cannot find install" >&2
+  exit 1
+end
+
+# ## Uninstall Grunt
+sudo -H npm uninstall -g grunt-cli
+or begin
+  set -l err $status
+  echo "Error: Failed to uninstall $PROG_NAME"
+  echo "Error: npm uninstall -g grunt-cli failed" >&2
+  exit $err
+end
+
+# ## Clean npm cache
+sudo -H npm cache clean
+or begin
+  set -l err $status
+  echo "Error: Failed to clear cache $PROG_NAME"
+  echo "Error: npm cache clean failed" >&2
+  exit $err
+end
+
+# ## Success
+echo "
+$PROG_NAME has been uninstalled successfully.
+"
+
+end
+main
+# vim: set filetype=fish:

--- a/uninstallers/mean
+++ b/uninstallers/mean
@@ -1,0 +1,43 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Mean"
+set -l USERNAME     $USER
+
+# ## Check Requirements
+# ### Check if installed
+if not which mean > /dev/null
+  echo "
+A $PROG_NAME installation cannot be found.
+"
+  echo "Req Error: Cannot find install" >&2
+  exit 1
+end
+
+# ## Uninstall Mean
+sudo -H npm uninstall -g mean-cli
+or begin
+  set -l err $status
+  echo "Error: Failed to uninstall $PROG_NAME"
+  echo "Error: npm uninstall -g mean-cli failed" >&2
+  exit $err
+end
+
+# ## Clean npm cache
+sudo -H npm cache clean
+or begin
+  set -l err $status
+  echo "Error: Failed to clear cache $PROG_NAME"
+  echo "Error: npm cache clean failed" >&2
+  exit $err
+end
+
+# ## Success
+echo "
+$PROG_NAME has been uninstalled successfully.
+"
+
+end
+main
+# vim: set filetype=fish:

--- a/uninstallers/mean-io-stack
+++ b/uninstallers/mean-io-stack
@@ -1,0 +1,62 @@
+#!/usr/bin/env fish
+function main
+
+# ## Config
+set -l PROG_NAME    "Mean.io Stack"
+set -l REQ_STORAGE  697036
+set -l USERNAME     $USER
+
+# ## Set installs in this bundle
+set -l bundled mongodb grunt mean
+set -l mongodb "mongod" 
+set -l grunt "grunt"
+set -l mean "mean"
+
+# ## Confirm
+echo "
+By uninstalling $PROG_NAME, you will FULLY DELETE the kpm installation of
+$PROG_NAME. This includes all programs included within the bundle:
+$bundled
+
+This cannot be undone.
+
+Are you sure?
+"
+for x in (seq 3)
+  echo -n "(yes/no, y/n) "
+  read -l confirm < /dev/tty
+  or begin
+    echo "Input Error: Empty confirm response" >&2
+    exit 1
+  end
+  switch "$confirm"
+    case "yes" "y"
+      break
+    case "no" "n"
+      exit 1
+    case "*"
+      if test "$x" -eq 3
+        echo -e "\nAborting after 3 failed attempts"
+        exit 1
+      else
+        echo -e "\nInvalid response, please retry."
+      end
+  end
+end
+
+# ## Unnstall everything in the bundle
+for bundle in $bundled
+	if which $$bundle > /dev/null
+   	 	echo "Installing $bundle"
+		kpm uninstall $bundle
+	end
+end
+
+# ## Complete
+echo "---------------------------------------------------------------------------------"
+echo "Uninstall complete, all uninstalls in $PROG_NAME completed successfully.  "
+echo "---------------------------------------------------------------------------------"
+
+end
+main
+# vim: set filetype=fish:


### PR DESCRIPTION
Installers and uninstallers for the MEAN stack from http://mean.io.

Notes: Node is part of this stack, but I didn't add it to the install/uninstall as it is pre-installed on the stock Koding VM. Build-essentials is not required to install the mean.io stack, however I included it in the install as it IS required to build the first MEAN application and including it here will streamline the process of using the stack.
